### PR TITLE
Fix crash when attempting to bind P2Ps on network with Security Station 

### DIFF
--- a/src/main/java/com/projecturanus/betterp2p/util/p2p/P2PUtil.kt
+++ b/src/main/java/com/projecturanus/betterp2p/util/p2p/P2PUtil.kt
@@ -14,6 +14,7 @@ import com.projecturanus.betterp2p.network.P2PInfo
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagCompound
+import net.minecraft.util.EnumHand
 
 val PartP2PTunnel<*>.colorCode: Array<AEColor> get() = Platform.p2p().toColors(this.frequency)
 
@@ -42,23 +43,23 @@ fun linkP2P(player: EntityPlayer, inputIndex: Int, outputIndex: Int, status: P2P
     // TODO reduce changes
     if (input.frequency.toInt() == 0 || input.isOutput) {
         frequency = cache.newFrequency()
-        updateP2P(input, frequency, false)
+        updateP2P(input, frequency, player, false)
     }
     if (cache.getInputs(frequency, input.javaClass) != null) {
         val originalInputs = cache.getInputs(frequency, input.javaClass)
         for (originalInput in originalInputs) {
             if (originalInput != input)
-                updateP2P(originalInput, frequency, true)
+                updateP2P(originalInput, frequency, player, true)
         }
     }
 
-    return updateP2P(input, frequency, false) to updateP2P(output, frequency, true)
+    return updateP2P(input, frequency, player, false) to updateP2P(output, frequency, player, true)
 }
 
 /**
  * Due to Applied Energistics' limit
  */
-fun updateP2P(tunnel: PartP2PTunnel<*>, frequency: Short, output: Boolean): PartP2PTunnel<*> {
+fun updateP2P(tunnel: PartP2PTunnel<*>, frequency: Short, player: EntityPlayer, output: Boolean): PartP2PTunnel<*> {
     val side = tunnel.side
     tunnel.host.removePart(side, true)
 
@@ -79,7 +80,7 @@ fun updateP2P(tunnel: PartP2PTunnel<*>, frequency: Short, output: Boolean): Part
     data.setIntArray("colorCode", colorCode)
 
     val newType = ItemStack(data)
-    val dir: AEPartLocation = tunnel.host?.addPart(newType, side, null, null) ?: throw RuntimeException("Cannot bind")
+    val dir: AEPartLocation = tunnel.host?.addPart(newType, side, player, EnumHand.MAIN_HAND) ?: throw RuntimeException("Cannot bind")
     val newBus: IPart = tunnel.host.getPart(dir)
 
     if (newBus is PartP2PTunnel<*>) {


### PR DESCRIPTION
When interacting with a network containing a Security Station *without* a blank card, having `null` as the player was causing the crash displayed in issues #1 and #5. This is consistently reproducible by:
1. Place down 2 p2ps, a cable, a security station, and a source of power.
2. attempt to bind one p2p to another.
3. observe the crash as described in issue #1.
4. when logging back in, the P2P that was attempted to be bound no longer exists, due to https://github.com/PrototypeTrousers/Applied-Energistics-2/issues/149 (discovered while testing this).

By passing in the player (and hand, to avoid a NPE), the crash is avoided in the most common cases. However, the crash still occurs when attempting to bind P2Ps in a network the player does not have access to. This is unlikely to occur, and I believe this would be best resolved via a fix to this process in AE2-EL.

I have built and tested this change (needed to change the forge version to `14.23.5.2847` in `gradle.properties` to start). If the `master` branch is not deprecated, this change should be applied there too.