### PR TITLE
Update AE2 mod ID

### DIFF
--- a/common/src/main/resources/assets/betterp2p/recipes/advanced_memory_card.json
+++ b/common/src/main/resources/assets/betterp2p/recipes/advanced_memory_card.json
@@ -2,10 +2,10 @@
     "type": "minecraft:crafting_shapeless",
     "ingredients": [
         {
-            "item": "appliedenergistics2:memory_card"
+            "item": "ae2:memory_card"
         },
         {
-            "item": "appliedenergistics2:network_tool"
+            "item": "ae2:network_tool"
         }
     ],
     "result": {


### PR DESCRIPTION
Should fix the issue of the advanced memory card being uncraftable:
    https://github.com/LasmGratel/BetterP2P/issues/15